### PR TITLE
Better skinny tiddler management

### DIFF
--- a/SyncFilter.tid
+++ b/SyncFilter.tid
@@ -1,0 +1,3 @@
+title: $:/config/SyncFilter
+
+[is[tiddler]] -[[$:/HistoryList]] -[[$:/Import]] -[[$:/isEncrypted]] -[prefix[$:/status]] -[prefix[$:/state]] -[prefix[$:/temp]] -[prefix[$:/plugins/wshallum/couchadaptor/]] -[[$:/StoryList]]

--- a/couchapp.js
+++ b/couchapp.js
@@ -9,8 +9,15 @@ ddoc = {
 
 // _id is title
 ddoc.views['skinny-tiddlers'] = {
-	map: function(doc) {
-		emit(doc._id, doc._rev);
+	map: function (doc) {
+    		fields = {};
+    		for(var field in doc.fields ){
+    			//text should not be included, neither title. We also avoid to send too long fields
+			 if( ['text','title'].indexOf(field) === -1 && doc.fields[field].length < 1024){
+			 	fields[field] = doc.fields[field];
+			 }
+    		}
+		emit(doc._id,fields);
 	}
 }
 

--- a/couchdbadaptor.js
+++ b/couchdbadaptor.js
@@ -260,9 +260,12 @@ CouchAdaptor.prototype.deleteTiddler = function(title, callback, options) {
 	});
 };
 
+/* The response should include the tiddler fields as an object in the value property*/
 CouchAdaptor.prototype.convertFromSkinnyTiddler = function(row) {
-	return {title: this.demangleTitle(row.key), revision: row.value};
+	row.value.title=this.demangleTitle(row.id); //inject the title because is not included in the fields
+	return row.value;
 }
+
 
 /* 
  * Copy all fields to "fields" sub-object except for the "revision" field. 


### PR DESCRIPTION
This pull request adds:
* A new view for the couch app that sends the fields as an object in the value field of the response
* A new convertFromSkinnyTiddler function to manage the new response from the server
* A SyncFilter to avoid plugin configuration changes be synced back to the server