### PR TITLE
Added revision to the returned fields

### DIFF
--- a/couchapp.js
+++ b/couchapp.js
@@ -17,6 +17,7 @@ ddoc.views['skinny-tiddlers'] = {
 			 	fields[field] = doc.fields[field];
 			 }
     		}
+    		fields.revision = doc._rev; //required for proper sync 
 		emit(doc._id,fields);
 	}
 }


### PR DESCRIPTION
Revision it's mandatory on skinny. If it is not present the sync adaptor will re-download the tiddler every time skinny tiddlers are requested.
Since it is not part of the fields of the doc we should inject it.